### PR TITLE
Invoke Fabric API's ServerWorldEvents.LOAD when loading a new world

### DIFF
--- a/src/main/java/net/lerariemann/infinity/mixin/MinecraftServerMixin.java
+++ b/src/main/java/net/lerariemann/infinity/mixin/MinecraftServerMixin.java
@@ -1,6 +1,7 @@
 package net.lerariemann.infinity.mixin;
 
 import com.google.common.collect.ImmutableList;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.lerariemann.infinity.InfinityMod;
 import net.lerariemann.infinity.access.MinecraftServerAccess;
 import net.lerariemann.infinity.dimensions.RandomProvider;
@@ -86,6 +87,7 @@ public class MinecraftServerMixin implements MinecraftServerAccess {
             worlds.put(key, world);
             worldsToAdd.clear();
         }));
+        ServerWorldEvents.LOAD.invoker().onWorldLoad((MinecraftServer) (Object) this, world);
     }
 
     @Override


### PR DESCRIPTION
Certain mods listen to `ServerWorldEvents.LOAD` to run initialization code before a world starts ticking, which breaks with Infinite Dimension's worlds, since that event is never invoked by its world loading code. See https://github.com/MeatWheeze/NeepMeat/issues/8.

This PR simply invokes the event appropriately.