### PR TITLE
Fix crash when rendering Chaotic Mobs

### DIFF
--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalCreeper.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalCreeper.java
@@ -13,6 +13,7 @@ import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.world.LocalDifficulty;
@@ -81,7 +82,12 @@ public class DimensionalCreeper extends CreeperEntity implements TintableEntity 
     }
     @Override
     public boolean hasCustomName() {
-        return false;
+        return super.hasCustomName();
+    }
+
+    @Override
+    public Text getName() {
+        return super.getName();
     }
 
     @Override

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalCreeper.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalCreeper.java
@@ -79,6 +79,10 @@ public class DimensionalCreeper extends CreeperEntity implements TintableEntity 
     public int getAge() {
         return age;
     }
+    @Override
+    public boolean hasCustomName() {
+        return false;
+    }
 
     @Override
     public int getColorRaw() {

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSkeleton.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSkeleton.java
@@ -23,6 +23,7 @@ import net.minecraft.potion.Potions;
 import net.minecraft.registry.Registries;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.LocalDifficulty;
@@ -47,7 +48,12 @@ public class DimensionalSkeleton extends SkeletonEntity implements TintableEntit
     }
     @Override
     public boolean hasCustomName() {
-        return false;
+        return super.hasCustomName();
+    }
+
+    @Override
+    public Text getName() {
+        return super.getName();
     }
 
     @Override

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSkeleton.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSkeleton.java
@@ -45,6 +45,10 @@ public class DimensionalSkeleton extends SkeletonEntity implements TintableEntit
     public int getAge() {
         return age;
     }
+    @Override
+    public boolean hasCustomName() {
+        return false;
+    }
 
     @Override
     @Nullable

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
@@ -45,6 +45,11 @@ public class DimensionalSlime extends SlimeEntity implements TintableEntity {
     }
 
     @Override
+    public boolean hasCustomName() {
+        return false;
+    }
+
+    @Override
     protected void initDataTracker() {
         super.initDataTracker();
         this.dataTracker.startTracking(core, Blocks.STONE.getDefaultState());

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
@@ -21,6 +21,7 @@ import net.minecraft.particle.DustParticleEffect;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.registry.Registries;
 import net.minecraft.sound.SoundEvent;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.LocalDifficulty;
 import net.minecraft.world.ServerWorldAccess;
@@ -43,6 +44,7 @@ public class DimensionalSlime extends SlimeEntity implements TintableEntity {
     public int getAge() {
         return age;
     }
+
 
     @Override
     public boolean hasCustomName() {

--- a/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
+++ b/src/main/java/net/lerariemann/infinity/entity/custom/DimensionalSlime.java
@@ -48,7 +48,12 @@ public class DimensionalSlime extends SlimeEntity implements TintableEntity {
 
     @Override
     public boolean hasCustomName() {
-        return false;
+        return super.hasCustomName();
+    }
+
+    @Override
+    public Text getName() {
+        return super.getName();
     }
 
     @Override


### PR DESCRIPTION
This should fix the inheritance crash when rendering Chaotic Slimes and Chaotic Creepers (also added the fix to Skeletons in case they're also broken).