### PR TITLE
Portals are now automatically opened

### DIFF
--- a/src/main/java/net/lerariemann/infinity/mixin/NetherPortalBlockMixin.java
+++ b/src/main/java/net/lerariemann/infinity/mixin/NetherPortalBlockMixin.java
@@ -1,18 +1,24 @@
 package net.lerariemann.infinity.mixin;
 
+import net.lerariemann.infinity.access.MinecraftServerAccess;
 import net.lerariemann.infinity.block.custom.NeitherPortalBlock;
+import net.lerariemann.infinity.dimensions.RandomProvider;
 import net.lerariemann.infinity.var.ModCommands;
+import net.lerariemann.infinity.var.ModCriteria;
+import net.lerariemann.infinity.var.ModStats;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.NetherPortalBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -36,6 +42,18 @@ public class NetherPortalBlockMixin {
 					long i = ModCommands.getDimensionSeed(compound, server);
 					boolean b = server.getWorld(RegistryKey.of(RegistryKeys.WORLD, new Identifier("infinity:generated_" + i))) != null;
 					NeitherPortalBlock.modifyPortal(world, pos, state, i, b);
+					MinecraftServer s = world.getServer();
+					RandomProvider prov = ((MinecraftServerAccess)(s)).getDimensionProvider();
+					boolean bl = prov.portalKey.isBlank();
+					if (bl) {
+						NeitherPortalBlock.open(s, world, pos, false);
+						PlayerEntity player = world.getClosestPlayer(pos.getX(), pos.getY(), pos.getZ(), 5, false);
+                        if (player != null) {
+							player.increaseStat(ModStats.DIMS_OPENED_STAT, 1);
+							ModCriteria.DIMS_OPENED.trigger((ServerPlayerEntity)player);
+							player.increaseStat(ModStats.PORTALS_OPENED_STAT, 1);
+						}
+					}
 					entity.remove(Entity.RemovalReason.CHANGED_DIMENSION);
 				}
 			}

--- a/src/main/resources/assets/infinity/lang/en_us.json
+++ b/src/main/resources/assets/infinity/lang/en_us.json
@@ -24,7 +24,7 @@
   "stat.infinity.dimensions_opened_stat": "Unique dimensions discovered",
   "stat.infinity.worlds_destroyed_stat": "Unique dimensions destroyed",
   "advancements.infinity.multiverse_start.title": "Welcome to the multiverse",
-  "advancements.infinity.multiverse_start.description": "Throw a written book into a nether portal. Right click the portal.",
+  "advancements.infinity.multiverse_start.description": "Throw a written book into a nether portal.",
   "advancements.infinity.book_box.title": "Delving into chaos",
   "advancements.infinity.book_box.description": "Throw a bookshelf into your new portal",
   "advancements.infinity.library.title": "Ain't no way i'm reading all that",


### PR DESCRIPTION
Portals no longer require a right click to open when a portal key is not set, instead opening when the book makes contact with the portal. The achievement and stats are granted to the closest player within five blocks, if one is present.