### PR TITLE
Preserve Shader when F5 is pressed

### DIFF
--- a/src/main/java/net/lerariemann/infinity/mixin/options/GameRendererMixin.java
+++ b/src/main/java/net/lerariemann/infinity/mixin/options/GameRendererMixin.java
@@ -1,10 +1,15 @@
 package net.lerariemann.infinity.mixin.options;
 
 import net.lerariemann.infinity.access.GameRendererAccess;
+import net.lerariemann.infinity.options.ShaderLoader;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
 public class GameRendererMixin implements GameRendererAccess {
@@ -14,5 +19,11 @@ public class GameRendererMixin implements GameRendererAccess {
     @Override
     public void loadPP(Identifier id) {
         loadPostProcessor(id);
+    }
+
+    @Inject(method = "onCameraEntitySet", at = @At("TAIL"))
+    private void preserveShaderThirdPerson(CallbackInfo ci) {
+        ShaderLoader.reloadShaders(MinecraftClient.getInstance(), true);
+
     }
 }


### PR DESCRIPTION
When F5 is pressed, custom shaders are reset. This commit reloads the current shader when the player's perspective changes to ensure it is not lost.