### PR TITLE
Modify config generation to use the `File.separator` value instead of a hardcoded "/"

### DIFF
--- a/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
+++ b/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
@@ -4,6 +4,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.lerariemann.infinity.InfinityMod;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,7 +18,7 @@ public class ConfigManager {
         Path endfile = Paths.get("config/" + InfinityMod.MOD_ID + fullname);
         try {
             if (!endfile.toFile().exists() && fullname.endsWith(".json")) {
-                int i = fullname.lastIndexOf("/");
+                int i = fullname.lastIndexOf(File.separator);
                 if (i>0) {
                     String directory_name = fullname.substring(0, i);
                     Files.createDirectories(Paths.get("config/" + InfinityMod.MOD_ID + directory_name));


### PR DESCRIPTION
The config JSON files fail to copy when building on Windows, due to the use of the incorrect file path separator ("/").