### PR TITLE
Bugfix/fix launch crash

### DIFF
--- a/src/main/java/net/lerariemann/infinity/util/CommonIO.java
+++ b/src/main/java/net/lerariemann/infinity/util/CommonIO.java
@@ -54,6 +54,10 @@ public class CommonIO {
         }
     }
 
+    public static int getLatestVersion() {
+        return (int) 1.7;
+    }
+
     public static NbtCompound read(File file) {
         String content;
         try {

--- a/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
+++ b/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
@@ -28,7 +28,7 @@ public class ConfigManager {
             }
             if (endfile.toFile().exists() && fullname.endsWith(".json")) {
                 int version_old = CommonIO.getVersion(endfile.toFile());
-                int version_new = CommonIO.getVersion(path.toFile());
+                int version_new = (int) 1.7;
                 if (version_new > version_old) {
                     Files.copy(path, endfile, REPLACE_EXISTING);
                 }

--- a/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
+++ b/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
@@ -28,7 +28,7 @@ public class ConfigManager {
             }
             if (endfile.toFile().exists() && fullname.endsWith(".json")) {
                 int version_old = CommonIO.getVersion(endfile.toFile());
-                int version_new = (int) 1.7;
+                int version_new = CommonIO.getLatestVersion();
                 if (version_new > version_old) {
                     Files.copy(path, endfile, REPLACE_EXISTING);
                 }


### PR DESCRIPTION
The auto-updater seems to be attempting to read from the current specified pack version inside the JAR. This causes a crash on startup outside of the dev environment. As a (possibly) temporary fix, I've created a dedicated version for reading the current infinity config version.