### PR TITLE
Allow for developing locally on Windows

### DIFF
--- a/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
+++ b/src/main/java/net/lerariemann/infinity/util/ConfigManager.java
@@ -4,6 +4,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.lerariemann.infinity.InfinityMod;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,7 +20,15 @@ public class ConfigManager {
         Path endfile = Paths.get("config/" + InfinityMod.MOD_ID + fullname);
         try {
             if (!endfile.toFile().exists() && fullname.endsWith(".json")) {
-                int i = fullname.lastIndexOf("/");
+                String separator;
+                if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
+                    separator = File.separator;
+                }
+                else {
+                    separator = "/";
+                }
+
+                int i = fullname.lastIndexOf(separator);
                 if (i>0) {
                     String directory_name = fullname.substring(0, i);
                     Files.createDirectories(Paths.get("config/" + InfinityMod.MOD_ID + directory_name));


### PR DESCRIPTION
While in production, both Windows and Linux users use the hardcoded `/` character, in development File.separator is required (on Windows). This PR adapts the config generation accordingly. 